### PR TITLE
Disable script

### DIFF
--- a/disable-local-user.sh
+++ b/disable-local-user.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+function usage {
+        echo "Usage: $(basename $0) [-adr] <username>" 2>&1
+	echo '   -d   Deletes user account(s) instead of simply disabling'
+	echo '   -r   Removes the home directorys associated with the account(s)'
+	echo '   -a   Creates an archive of the home directory associated with each user account'
+        exit 1
+}
+
+if [[ $UID != 0 ]]
+then
+    echo "Please run this script with sudo:"
+    echo "sudo $0 $*"
+    exit 1
+fi
+
+optstring=":ard"
+
+while getopts ${optstring} arg; do
+  case ${arg} in
+    a)
+      echo "option a"
+      ;;
+    d)
+      echo "option d"
+      ;;
+    r)
+      echo "option r"
+      ;;
+    :)
+      echo "$0: Must supply an argument to -$OPTARG." >&2
+      exit 1
+      ;;
+    ?)
+      echo "Invalid option: -${OPTARG}."
+      exit 1
+      ;;
+  esac
+done
+
+if [ $(( $# - $OPTIND )) -lt 1 ]; then
+    usage
+fi
+
+username=$(@:$OPTIND:1)
+
+echo $username
+
+passwd $username -l
+
+
+
+

--- a/disable-local-user.sh
+++ b/disable-local-user.sh
@@ -49,22 +49,24 @@ fi
 
 username=$1
 
-echo $username
-
 if [ $ARCHIVE -eq 1 ]; then
     if [ ! -d "/archive" ]; then
         echo "Directory '/archive' not found; creating /archive"
 	mkdir /archive
     fi
+    echo "Archiving contents of /home/$username to /archive"
     cp -r /home/$username /archive
 fi
 
 if [ $USERDEL -eq 1 ]; then
+    echo "Deleting user account: $username"
     userdel $username
 else
+    echo "Disabling user account: $username"
     passwd $username -l
 fi
 
 if [ $DELHOME -eq 1 ]; then
+    echo "Deleting home directory for user $username"
     rm -rf /home/$username
 fi

--- a/disable-local-user.sh
+++ b/disable-local-user.sh
@@ -63,7 +63,7 @@ if [ $USERDEL -eq 1 ]; then
     userdel $username
 else
     echo "Disabling user account: $username"
-    passwd $username -l
+    usermod --expiredate 1 $username
 fi
 
 if [ $DELHOME -eq 1 ]; then

--- a/disable-local-user.sh
+++ b/disable-local-user.sh
@@ -16,20 +16,20 @@ then
 fi
 
 optstring=":ard"
-ARCHIVE=false
-USERDEL=false
-DELHOME=false
+ARCHIVE=0
+USERDEL=0
+DELHOME=0
 
 while getopts ${optstring} arg; do
   case ${arg} in
     a)
-      ARCHIVE=true
+      ARCHIVE=1
       ;;
     d)
-      USERDEL=true
+      USERDEL=1
       ;;
     r)
-      DELHOME=true
+      DELHOME=1
       ;;
     :)
       echo "$0: Must supply an argument to -$OPTARG." >&2
@@ -51,7 +51,7 @@ username=$1
 
 echo $username
 
-if [ $ARCHIVE ]; then
+if [ $ARCHIVE -eq 1 ]; then
     if [ ! -d "/archive" ]; then
         echo "Directory '/archive' not found; creating /archive"
 	mkdir /archive
@@ -59,12 +59,12 @@ if [ $ARCHIVE ]; then
     cp -r /home/$username /archive
 fi
 
-if [ $USERDEL ]; then
+if [ $USERDEL -eq 1 ]; then
     userdel $username
 else
     passwd $username -l
 fi
 
-if [ $DELHOME ]; then
+if [ $DELHOME -eq 1 ]; then
     rm -rf /home/$username
 fi

--- a/disable-local-user.sh
+++ b/disable-local-user.sh
@@ -16,17 +16,20 @@ then
 fi
 
 optstring=":ard"
+ARCHIVE=false
+USERDEL=false
+DELHOME=false
 
 while getopts ${optstring} arg; do
   case ${arg} in
     a)
-      echo "option a"
+      ARCHIVE=true
       ;;
     d)
-      echo "option d"
+      USERDEL=true
       ;;
     r)
-      echo "option r"
+      DELHOME=true
       ;;
     :)
       echo "$0: Must supply an argument to -$OPTARG." >&2
@@ -39,16 +42,29 @@ while getopts ${optstring} arg; do
   esac
 done
 
-if [ $(( $# - $OPTIND )) -lt 1 ]; then
+shift $((OPTIND-1))
+if [ $# -lt 1 ]; then
     usage
 fi
 
-username=$(@:$OPTIND:1)
+username=$1
 
 echo $username
 
-passwd $username -l
+if [ $ARCHIVE ]; then
+    if [ ! -d "/archive" ]; then
+        echo "Directory '/archive' not found; creating /archive"
+	mkdir /archive
+    fi
+    cp -r /home/$username /archive
+fi
 
+if [ $USERDEL ]; then
+    userdel $username
+else
+    passwd $username -l
+fi
 
-
-
+if [ $DELHOME ]; then
+    rm -rf /home/$username
+fi


### PR DESCRIPTION
# TODO:

- Accepts a list of usernames as arguments.  At least one username is required or the script will display a usage statement much like you would find in a man page and return an exit status of 1.  All messages associated with this event will be displayed on standard error.

- Refuses to disable or delete any accounts that have a UID less than 1,000.

- Only system accounts should be modified by system administrators.  Only allow the help desk team to change user accounts.

- Informs the user if the account was not able to be disabled, deleted, or archived for some reason.
